### PR TITLE
Fix incorrectly cropped images

### DIFF
--- a/media_pipelines/image_pull/PADTextureDownload.py
+++ b/media_pipelines/image_pull/PADTextureDownload.py
@@ -150,7 +150,8 @@ for asset in assets:
                 break
             else: # is a bug a la polowne, crop garbage pixels off the bottom
                 img = img.crop((0,0,img.width,IMAGE_SIZE[1]))
-            img = img.crop(img.getbbox())
+                _,y0,_,y1 = img.getbbox()
+                img = img.crop((0,y0,img.width,y1))
 
         old_size = img.size
 


### PR DESCRIPTION
Fixes:
1. Pixel images which were not split correctly [example](https://d1kpnpud0qoyxf.cloudfront.net/media/portraits/03868.png)
2. Bugged images with excess empty space at the bottom [example](https://d1kpnpud0qoyxf.cloudfront.net/media/portraits/05991.png)

~~For images which are too tall:~~
- ~~Check if bottom of image (below `IMAGE_SIZE[1]`) is >99% transparent~~
- ~~If so, find the first transparent row from the bottom and crop off everything below~~
- ~~Then crop to contents using getbbox()~~

~~Currently this should only modify 3662, 3838, 5990, and 5991~~

This is untested as I don't have the proper environment, though I have tested the logic myself with an old PADTextureTool and set of monster images.