### PR TITLE
change cutoff for cards

### DIFF
--- a/media_pipelines/image_pull/PADTextureDownload.py
+++ b/media_pipelines/image_pull/PADTextureDownload.py
@@ -92,7 +92,7 @@ for asset in assets:
     should_always_process = False
     if 'card' in raw_file_path.lower():
         num = int(raw_file_name.rstrip('.bc').lstrip('cards_'))
-        if num >= 45:
+        if num >= 57:
             # Arbitrary cutoff; all the slots below here have been filled, no need to
             # keep downloading/processing
             should_always_process = True   


### PR DESCRIPTION
All slots below cards_057 have their slots filled.
57 specifically has a single slot open right now.

Instead of always downloading >= 45, now does >= 57.
Minor change, but slightly faster*ish* in the long run.