### PR TITLE
Fixed duration missing for awakening attack boost/shield

### DIFF
--- a/etl/pad/raw/skills/jp/active_skill_text.py
+++ b/etl/pad/raw/skills/jp/active_skill_text.py
@@ -227,14 +227,14 @@ class JpASTextConverter(JpBaseTextConverter, BaseASTextConverter):
         return skill_text
 
     def awakening_attack_boost_convert(self, act):
-        skill_text = 'チーム内の'
+        skill_text = self.fmt_duration(act.duration) + 'チーム内の'
         awakens = [self.AWAKENING_MAP[a] for a in act.awakenings]
         skill_text += self.concat_list_and(filter(None, awakens))
         skill_text += 'の覚醒数1つにつき攻撃力が{}％上がる'.format(fmt_mult(act.amount_per * 100))
         return skill_text
 
     def awakening_shield_convert(self, act):
-        skill_text = 'チーム内の'
+        skill_text = self.fmt_duration(act.duration) + 'チーム内の'
         awakens = [self.AWAKENING_MAP[a] for a in act.awakenings]
         skill_text += self.concat_list_and(filter(None, awakens))
         skill_text += 'の覚醒数1つにつき受けるダメージを{}％減少'.format(fmt_mult(act.amount_per * 100))

--- a/etl/pad/raw/skills/jp/leader_skill_text.py
+++ b/etl/pad/raw/skills/jp/leader_skill_text.py
@@ -180,11 +180,14 @@ class JpLSTextConverter(JpBaseTextConverter):
     def mass_match_text(self, ls):
         stat_text = self.fmt_stats_type_attr_bonus(ls, reduce_join_txt='、', skip_attr_all=True,
                                                    atk=ls.min_atk, rcv=ls.min_rcv)
-        skill_text = 'ドロップを{}個{}つなげて消すと{}'.format(ls.min_count,
+        skill_text = 'を{}個{}つなげて消すと{}'.format(ls.min_count,
                                               '以上' if ls.max_count != ls.min_count else '',
                                               stat_text)
-        if self.fmt_multi_attr(ls.match_attributes):
-            skill_text = self.fmt_multi_attr(ls.match_attributes) + skill_text
+        attr_text = self.fmt_multi_attr(ls.match_attributes)
+        if attr_text:
+            skill_text = attr_text + skill_text
+        else:
+            skill_text = 'ドロップ' + skill_text
         if ls.max_count != ls.min_count and ls.max_count > 0:
             skill_text += '、最大{}個で{}倍'.format(ls.max_count, fmt_mult(ls.atk))
         return skill_text + '。'

--- a/etl/pad/raw/skills/jp/leader_skill_text.py
+++ b/etl/pad/raw/skills/jp/leader_skill_text.py
@@ -180,7 +180,7 @@ class JpLSTextConverter(JpBaseTextConverter):
     def mass_match_text(self, ls):
         stat_text = self.fmt_stats_type_attr_bonus(ls, reduce_join_txt='、', skip_attr_all=True,
                                                    atk=ls.min_atk, rcv=ls.min_rcv)
-        skill_text = 'を{}個{}つなげて消すと{}'.format(ls.min_count,
+        skill_text = 'ドロップを{}個{}つなげて消すと{}'.format(ls.min_count,
                                               '以上' if ls.max_count != ls.min_count else '',
                                               stat_text)
         if self.fmt_multi_attr(ls.match_attributes):


### PR DESCRIPTION
Fixed duration missing for awakening attack boost/shield in Japanese description.

[diff.txt](https://github.com/TsubakiBotPad/pad-data-pipeline/files/5212180/diff.txt)
