### PR TITLE
Added LSColorCrossCombo

### DIFF
--- a/etl/pad/raw/skills/en/leader_skill_text.py
+++ b/etl/pad/raw/skills/en/leader_skill_text.py
@@ -260,6 +260,10 @@ class EnLSTextConverter(EnBaseTextConverter):
     def heart_cross_combo_text(self, ls):
         return 'Increase combo by {} when matching 5 Heal orbs in a cross formation'.format(ls.bonus_combos)
 
+    def color_cross_combo_text(self, ls):
+        attrs = self.attributes_to_str(ls.attributes, concat='or')
+        return 'Increase combo by {} for each cross of 5 {} orbs'.format(ls.bonus_combos, attrs)
+
     def multi_play_text(self, ls):
         multiplier_text = self.passive_stats_text(ls)
         return '{} when in multiplayer mode'.format(multiplier_text)

--- a/etl/pad/raw/skills/jp/leader_skill_text.py
+++ b/etl/pad/raw/skills/jp/leader_skill_text.py
@@ -252,6 +252,10 @@ class JpLSTextConverter(JpBaseTextConverter):
     def heart_cross_combo_text(self, ls):
         return '回復の5個十字消しで{}コンボ加算。'.format(ls.bonus_combos)
 
+    def color_cross_combo_text(self, ls):
+        attrs = self.attributes_to_str(ls.attributes, concat='か').replace('、', 'か')
+        return '{}の5個十字消しで{}コンボ加算。'.format(attrs, ls.bonus_combos)
+
     def multi_play_text(self, ls):
         multiplier_text = self.fmt_stats_type_attr_bonus(ls)
         return 'マルチプレイ時に{}。'.format(multiplier_text)

--- a/etl/pad/raw/skills/leader_skill_info.py
+++ b/etl/pad/raw/skills/leader_skill_info.py
@@ -1762,6 +1762,18 @@ class LSHeartCrossCombo(LeaderSkill):
     def text(self, converter) -> str:
         return converter.heart_cross_combo_text(self)
 
+class LSColorCrossCombo(LeaderSkill):
+    skill_type = 210
+
+    def __init__(self, ms: MonsterSkill):
+        data = merge_defaults(ms.data, [0, 0, 1])
+        self.bonus_combos = data[2]
+        self.attributes = binary_con(data[0])
+        super().__init__(210, ms, extra_combos=self.bonus_combos)
+
+    def text(self, converter) -> str:
+        return converter.color_cross_combo_text(self)
+
 def convert(skill_list: List[MonsterSkill]):
     results = {}
     for s in skill_list:
@@ -1910,4 +1922,5 @@ ALL_LEADER_SKILLS = [
     LSColorComboBonusDamage,
     LSColorComboBonusCombo,
     LSHeartCrossCombo,
+    LSColorCrossCombo,
 ]


### PR DESCRIPTION
Recent update has introduced a new leader skill type (210).

Reference: https://pad.gungho.jp/member/adjust/201013/index.html

Example: `光か闇の5個十字消しで1コンボ加算。`