### PR TITLE
Fix bug with PADTextureTool

### DIFF
--- a/media_pipelines/image_pull/PADTextureTool.py
+++ b/media_pipelines/image_pull/PADTextureTool.py
@@ -364,7 +364,9 @@ class TextureReader(object):
                     if encoding == R4G4B4A4 and len(binaryBlob) >= offset + 16:
                         # 8 bytes of idk perhaps image size | img width | img height | # of frames | idk maybe palette related
                         _,givenWidth,givenHeight,_,_ = struct.unpack('<8sHHHH',binaryBlob[offset:offset+16])
-
+                    if not givenWidth or not givenHeight:
+                        # if either dimension is 0, use the full image size instead
+                        givenWidth, givenHeight = width, height
                     yield Texture(width, height, name, binaryBlob[imageDataStart:imageDataEnd], encoding, min(width, givenWidth), min(height, givenHeight))
 
             offset += cls.textureBlockHeaderAlignment

--- a/media_pipelines/image_pull/PADTextureTool.py
+++ b/media_pipelines/image_pull/PADTextureTool.py
@@ -365,7 +365,7 @@ class TextureReader(object):
                         # 8 bytes of idk perhaps image size | img width | img height | # of frames | idk maybe palette related
                         _,givenWidth,givenHeight,_,_ = struct.unpack('<8sHHHH',binaryBlob[offset:offset+16])
 
-                    yield Texture(width, height, name, binaryBlob[imageDataStart:imageDataEnd], encoding, givenWidth, givenHeight)
+                    yield Texture(width, height, name, binaryBlob[imageDataStart:imageDataEnd], encoding, min(width, givenWidth), min(height, givenHeight))
 
             offset += cls.textureBlockHeaderAlignment
 


### PR DESCRIPTION
Some images (`MONS_5033_000` in particular) have no data in their header. In this case the image size was reported to be 43504x43504, which is far larger than the actual size of 1024x1024. I assume this is because the texture takes up the entire space so the header was just omitted. Anyway, if you try to download this image it will either result in an out of memory error or cause `blackenTransparentPixels()` to fail by trying to access pixels outside of the image.