### PR TITLE
Prevent dupes in intersection tables

### DIFF
--- a/etl/pad/storage/egg_machines_monsters.py
+++ b/etl/pad/storage/egg_machines_monsters.py
@@ -1,4 +1,5 @@
-from pad.db.sql_item import SimpleSqlItem
+from pad.db import sql_item
+from pad.db.sql_item import SimpleSqlItem, ExistsStrategy
 
 
 class EggMachinesMonster(SimpleSqlItem):
@@ -15,6 +16,22 @@ class EggMachinesMonster(SimpleSqlItem):
         self.monster_id = monster_id
         self.roll_chance = roll_chance
         self.egg_machine_id = egg_machine_id
+
+    def exists_strategy(self):
+        return ExistsStrategy.BY_VALUE
+
+    def value_exists_sql(self):
+        sql = """
+        SELECT egg_machine_monster_id FROM {table}
+        WHERE monster_id = {monster_id} AND egg_machine_id = {egg_machine_id}
+        """.format(table=self._table(), **sql_item.object_to_sql_params(self))
+        return sql
+
+    def _non_auto_insert_cols(self):
+        return [self._key()]
+
+    def _non_auto_update_cols(self):
+        return [self._key()]
 
     def __str__(self):
         return 'EggMachineMonster ({}-{}-{}-{})'.format(self.egg_machine_monster_id, self.monster_id, self.roll_chance,

--- a/etl/pad/storage/monster.py
+++ b/etl/pad/storage/monster.py
@@ -125,7 +125,6 @@ class Monster(SimpleSqlItem):
             diff_leader_skill=diff_leader_skill,
             diff_active_skill=diff_active_skill,
             base_id=o.cur_card.no_to_id(cur_card.base_id),
-            series_id=Series.UNSORTED_SERIES_ID,
             has_animation=o.has_animation,
             has_hqimage=o.has_hqimage,
             orb_skin_id=orb_skin_id,
@@ -181,7 +180,6 @@ class Monster(SimpleSqlItem):
                  diff_leader_skill: bool = None,
                  diff_active_skill: bool = None,
                  base_id: int = None,
-                 series_id: int = None,
                  has_animation: bool = None,
                  has_hqimage: bool = None,
                  orb_skin_id: int = None,
@@ -236,7 +234,6 @@ class Monster(SimpleSqlItem):
         self.diff_leader_skill = diff_leader_skill
         self.diff_active_skill = diff_active_skill
         self.base_id = base_id
-        self.series_id = series_id
         self.has_animation = has_animation
         self.has_hqimage = has_hqimage
         self.orb_skin_id = orb_skin_id
@@ -250,41 +247,12 @@ class Monster(SimpleSqlItem):
         return [
             'buy_mp',
             'reg_date',
-            'series_id',
             'has_animation',
             'has_hqimage',
         ]
 
     def __str__(self):
         return 'Monster({}): {}'.format(self.key_value(), self.name_en)
-
-
-class MonsterWithSeries(SimpleSqlItem):
-    """Monster helper for inserting series."""
-    KEY_COL = 'monster_id'
-
-    @classproperty
-    def TABLE(cls):
-        server = os.environ.get("CURRENT_PIPELINE_SERVER") or ""
-        if server.upper() == "NA":
-            return 'monsters_na'
-        # elif server.upper() == "JP":
-        #    return 'monsters_jp'
-        # elif server.upper() == "KR":
-        #     return 'monsters_kr'
-        else:
-            return 'monsters'
-
-    def __init__(self,
-                 monster_id: int = None,
-                 series_id: int = None,
-                 tstamp: int = None):
-        self.monster_id = monster_id
-        self.series_id = series_id
-        self.tstamp = tstamp
-
-    def __str__(self):
-        return 'Monster({}): {}'.format(self.key_value(), self.series_id)
 
 
 class MonsterWithExtraImageInfo(SimpleSqlItem):

--- a/etl/pad/storage/series.py
+++ b/etl/pad/storage/series.py
@@ -1,4 +1,5 @@
-from pad.db.sql_item import SimpleSqlItem
+from pad.db import sql_item
+from pad.db.sql_item import SimpleSqlItem, ExistsStrategy
 
 
 class Series(SimpleSqlItem):
@@ -49,6 +50,22 @@ class MonsterSeries(SimpleSqlItem):
         self.series_id = series_id
         self.tstamp = tstamp
         self.priority = priority
+
+    def exists_strategy(self):
+        return ExistsStrategy.BY_VALUE
+
+    def value_exists_sql(self):
+        sql = """
+        SELECT monster_series_id FROM {table}
+        WHERE monster_id = {monster_id} AND series_id = {series_id}
+        """.format(table=self._table(), **sql_item.object_to_sql_params(self))
+        return sql
+
+    def _non_auto_insert_cols(self):
+        return [self._key()]
+
+    def _non_auto_update_cols(self):
+        return [self._key()]
 
     def __str__(self):
         return 'MonsterSeries({}, {})'.format(self.key_value(), self.series_id)

--- a/etl/pad/storage/series.py
+++ b/etl/pad/storage/series.py
@@ -31,3 +31,24 @@ class Series(SimpleSqlItem):
 
     def __str__(self):
         return 'Series ({}): {}'.format(self.key_value(), self.name_en)
+
+
+class MonsterSeries(SimpleSqlItem):
+    """A monster's association with a series."""
+    TABLE = 'monster_series'
+    KEY_COL = 'monster_series_id'
+
+    def __init__(self,
+                 monster_series_id = None,
+                 monster_id: int = None,
+                 series_id: int = None,
+                 tstamp: int = None,
+                 priority: bool = None):
+        self.monster_series_id = monster_series_id or hash((monster_id, series_id))
+        self.monster_id = monster_id
+        self.series_id = series_id
+        self.tstamp = tstamp
+        self.priority = priority
+
+    def __str__(self):
+        return 'MonsterSeries({}, {})'.format(self.key_value(), self.series_id)

--- a/etl/pad/storage_processor/series_processor.py
+++ b/etl/pad/storage_processor/series_processor.py
@@ -45,7 +45,7 @@ class SeriesProcessor(object):
                 # Monster had no ancestor to look up the series of.
                 continue
 
-            ancestor_series_id = monster_id_to_series_id[ancestor_id]
+            ancestor_series_id = monster_id_to_series_id.get(ancestor_id, 0)
             if ancestor_series_id == 0:
                 # Ancestor also has no series.
                 continue

--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -1043,7 +1043,7 @@ DROP TABLE IF EXISTS `monster_series`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `monster_series` (
-  `monster_series_id` int(11) NOT NULL,
+  `monster_series_id` int(11) NOT NULL AUTO_INCREMENT,
   `monster_id` int(11) NOT NULL,
   `series_id` int(11) NOT NULL,
   `priority` tinyint(1) NOT NULL,

--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -1036,12 +1036,29 @@ DELIMITER ;
 /*!50003 SET collation_connection  = @saved_col_connection */ ;
 
 --
+-- Table structure for table `monster_series`
+--
+
+DROP TABLE IF EXISTS `monster_series`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `monster_series` (
+  `monster_series_id` int(11) NOT NULL,
+  `monster_id` int(11) NOT NULL,
+  `series_id` int(11) NOT NULL,
+  `priority` tinyint(1) NOT NULL,
+  `tstamp` int(11) NOT NULL,
+  PRIMARY KEY (`monster_id`, `series_id`),
+  KEY `tstamp` (`tstamp`),
+  CONSTRAINT `monster_series_fk_monster_id` FOREIGN KEY (`monster_id`) REFERENCES `monsters` (`monster_id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `monster_series_fk_series_id` FOREIGN KEY (`series_id`) REFERENCES `series` (`series_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
 -- Table structure for table `skill_condition`
 --
 
 DROP TABLE IF EXISTS `skill_condition`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `skill_condition` (
   `condition_id` int(11) NOT NULL,
   `condition_type` int(11) NOT NULL,

--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -1048,11 +1048,11 @@ CREATE TABLE `monster_series` (
   `series_id` int(11) NOT NULL,
   `priority` tinyint(1) NOT NULL,
   `tstamp` int(11) NOT NULL,
-  PRIMARY KEY (`monster_id`, `series_id`),
+  PRIMARY KEY (`monster_series_id`),
   KEY `tstamp` (`tstamp`),
   CONSTRAINT `monster_series_fk_monster_id` FOREIGN KEY (`monster_id`) REFERENCES `monsters` (`monster_id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
   CONSTRAINT `monster_series_fk_series_id` FOREIGN KEY (`series_id`) REFERENCES `series` (`series_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 --
 -- Table structure for table `skill_condition`


### PR DESCRIPTION
```sql
DROP TABLE IF EXISTS `monster_series`;
CREATE TABLE `monster_series` (
  `monster_series_id` int(11) NOT NULL AUTO_INCREMENT,
  `monster_id` int(11) NOT NULL,
  `series_id` int(11) NOT NULL,
  `priority` tinyint(1) NOT NULL,
  `tstamp` int(11) NOT NULL,
  PRIMARY KEY (`monster_series_id`),
  KEY `tstamp` (`tstamp`),
  CONSTRAINT `monster_series_fk_monster_id` FOREIGN KEY (`monster_id`) REFERENCES `monsters` (`monster_id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
  CONSTRAINT `monster_series_fk_series_id` FOREIGN KEY (`series_id`) REFERENCES `series` (`series_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
```