### PR TITLE
ASTimedEnemyAttrChange can only have one attr

### DIFF
--- a/etl/pad/raw/skills/active_skill_info.py
+++ b/etl/pad/raw/skills/active_skill_info.py
@@ -1143,7 +1143,7 @@ class ASTimedEnemyAttrChange(ActiveSkill):
     def __init__(self, ms: MonsterSkill):
         data = merge_defaults(ms.data, [0, 0])
         self.turns = data[0]
-        self.attribute = binary_con(data[1])
+        self.attribute = data[1]
         super().__init__(ms)
 
     def text(self, converter: ASTextConverter) -> str:


### PR DESCRIPTION
This may not work like this.  I may have to take `binary_con(data[1])[0]`, but we can't know until a AS of this type is released in any color other than red or blue.