### PR TITLE
Skip DCP in Pipeline

### DIFF
--- a/cronjobs/data_processor.sh
+++ b/cronjobs/data_processor.sh
@@ -26,6 +26,7 @@ flock -xn /tmp/dg_processor.lck python3 "${ETL_DIR}/data_processor.py" \
   --output_dir="${DADGUIDE_DATA_DIR}/processed" \
   --db_config="${DB_CONFIG}" \
   --server=$1 \
+  --skip_long \
   --doupdates
 
 human_fixes_check


### PR DESCRIPTION
I think I'll just turn this off for now.  I'm sick of getting 2 pings a day for a "failed" pipeline when it actually works fine.  I'll fix it eventually.